### PR TITLE
Wrap markup-fix comment in {% raw %} (Pages build fix)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,24 @@
 3. Submit a pull request
 
 All issues use standardized labels (type, severity, milestone).
+
+## GitHub Pages / Jekyll Liquid gotcha
+
+GitHub Pages renders this repo's Markdown through Jekyll. Jekyll's Liquid
+templating engine treats two CDSL markup conventions as template syntax:
+
+- `{%…%}` — the italic-span marker; collides with Liquid tag syntax.
+- `{{…}}` — the correction-record format `{{old -> new || date | author | URL |}}`;
+  collides with Liquid variable interpolation.
+
+A `.md` file containing either marker — even inside a fenced code block — breaks
+the Pages build. The fix is to wrap the whole file in `{% raw %}` and the matching
+closing tag. See [`pwgissues/issue174/comment_markup_fix.md`](pwgissues/issue174/comment_markup_fix.md)
+for a working example, and MWS PRs
+[#198](https://github.com/sanskrit-lexicon/MWS/pull/198),
+[#200](https://github.com/sanskrit-lexicon/MWS/pull/200),
+[#201](https://github.com/sanskrit-lexicon/MWS/pull/201)
+for the full org-wide precedent.
+
+When adding any new `.md` that quotes `<L>` records, italic markers, or sample
+entry text — wrap it.

--- a/pwgissues/issue174/comment_markup_fix.md
+++ b/pwgissues/issue174/comment_markup_fix.md
@@ -1,3 +1,4 @@
+{% raw %}
 ## Markup fixer + audit for `pwg.txt`
 
 Adding `08_markup_fix.py` to `pwgissues/issue174/`. It does two things, both safe to re-run after Phase B is applied **and** after @Andhrabharati's local-abbreviation overlay lands.
@@ -50,3 +51,4 @@ python 08_markup_fix.py pwg_with_abs.txt pwg_with_abs_fixed.txt
 ```
 
 Synthetic-input tests of the nesting fixer all pass.
+{% endraw %}


### PR DESCRIPTION
## Context

GitHub Pages build on `master` has been failing since **2026-05-18** (commit `c25385fa` — "Preliminary work on abbreviations. #174"). Eight consecutive builds have errored. The most recent commits (after `b74f7862` on 2026-05-16) all show `errored` in [the Pages build log](https://github.com/sanskrit-lexicon/PWG/deployments).

Cause is the same Jekyll/Liquid gotcha [recently fixed in MWS](https://github.com/sanskrit-lexicon/MWS/blob/master/CONTRIBUTING.md#github-pages--jekyll-liquid-gotcha) (PRs [#198](https://github.com/sanskrit-lexicon/MWS/pull/198), [#200](https://github.com/sanskrit-lexicon/MWS/pull/200), [#201](https://github.com/sanskrit-lexicon/MWS/pull/201)): a `.md` file in the repo quotes the CDSL `{%…%}` italic-span marker, and Jekyll's Liquid engine tries to parse it as template syntax — **even inside fenced code blocks**.

## Audit

Repo-wide grep of `*.md` on `master` for `{%[^%]*%}` and `{{[^{}]*}}`:

| File | Hits | Class |
|---|---|---|
| [pwgissues/issue174/comment_markup_fix.md](pwgissues/issue174/comment_markup_fix.md) | 3 (`{%des%}`, `{%unwürdig%}`, `{%Desmodium gangeticum%}` at L23/25) | `{%…%}` italic markers |

No `{{…}}` correction-record patterns in any `.md`. Just the one file.

## Fix

1. **`pwgissues/issue174/comment_markup_fix.md`** — whole-file `{% raw %}` … `{% endraw %}` wrap (the simplest, least-fragile pattern; rendered HTML is identical because Liquid consumes the wrapper before output).
2. **`CONTRIBUTING.md`** — appended a "GitHub Pages / Jekyll Liquid gotcha" section mirroring [the MWS precedent](https://github.com/sanskrit-lexicon/MWS/blob/master/CONTRIBUTING.md#github-pages--jekyll-liquid-gotcha), so any future doc quoting `<L>` records, italic markers, or sample entries gets wrapped pre-emptively.

## Diff

```
 CONTRIBUTING.md                          | 23 ++++++++++++++++++++++-
 pwgissues/issue174/comment_markup_fix.md |  2 ++
 2 files changed, 24 insertions(+), 1 deletion(-)
```

## Verification

Once merged, the Pages workflow re-runs against `master`. Expected: `success` on the next build, with `http://sanskrit-lexicon.github.io/PWG/` re-deployed. The Pages-config status (`gh api repos/sanskrit-lexicon/PWG/pages`) should flip from `errored` → `built`.

If a further Liquid issue appears in a file the grep missed, it'll surface as a separate "Liquid Exception" line in the next Pages build log — add the same wrap to that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)