### PR TITLE
seo: fix SEO/UX landing page — correct PWG badge, title, and browse URL

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -17,3 +17,4 @@
 ## ✅ Completed (Recent only)
 
 <!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->
+- 06-07-2026: /cologne-pages-landing — SEO landing + .nojekyll live (fixed a pre-existing landing page that mislabelled PWG as "PW" and linked a stale 2013 scan URL)

--- a/index.html
+++ b/index.html
@@ -3,28 +3,28 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch) (PW) · Cologne Digital Sanskrit Lexicon</title>
-<meta name="description" content="The “Großes Petersburger Wörterbuch” — Böhtlingk and Roth&#x27;s seven-volume Sanskrit–German dictionary (St. Petersburg, 1855–1875), the foundational scholarly Sanskrit lexicon from which later dictionaries drew. Digitised, corrected, and openly published by the Cologne Digital Sanskrit Lexicon.">
+<title>Sanskrit-Wörterbuch (PWG) · Cologne Digital Sanskrit Lexicon</title>
+<meta name="description" content="Böhtlingk &amp; Roth&#x27;s Great Petersburg Dictionary (1855–1875) — the foundational seven-volume Sanskrit–German lexicon of the 19th century and direct ancestor of Monier-Williams.">
 <link rel="canonical" href="https://sanskrit-lexicon.github.io/PWG/">
 <meta name="theme-color" content="#1f78b4">
-<meta name="author" content="Otto Böhtlingk &amp; Rudolph Roth">
+<meta name="author" content="Otto von Böhtlingk and Rudolph Roth">
 <meta name="robots" content="index,follow">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Cologne Digital Sanskrit Lexicon">
 <meta property="og:locale" content="en">
-<meta property="og:title" content="Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch) (PW)">
-<meta property="og:description" content="The “Großes Petersburger Wörterbuch” — Böhtlingk and Roth&#x27;s seven-volume Sanskrit–German dictionary (St. Petersburg, 1855–1875), the foundational scholarly Sanskrit lexicon from which later dictionaries drew. Digitised, corrected, and openly published by the Cologne Digital Sanskrit Lexicon.">
+<meta property="og:title" content="Sanskrit-Wörterbuch (PWG)">
+<meta property="og:description" content="Böhtlingk &amp; Roth&#x27;s Great Petersburg Dictionary (1855–1875) — the foundational seven-volume Sanskrit–German lexicon of the 19th century and direct ancestor of Monier-Williams.">
 <meta property="og:url" content="https://sanskrit-lexicon.github.io/PWG/">
 <meta property="og:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="Cologne Digital Sanskrit Lexicon">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch) (PW)">
-<meta name="twitter:description" content="The “Großes Petersburger Wörterbuch” — Böhtlingk and Roth&#x27;s seven-volume Sanskrit–German dictionary (St. Petersburg, 1855–1875), the foundational scholarly Sanskrit lexicon from which later dictionaries drew. Digitised, corrected, and openly published by the Cologne Digital Sanskrit Lexicon.">
+<meta name="twitter:title" content="Sanskrit-Wörterbuch (PWG)">
+<meta name="twitter:description" content="Böhtlingk &amp; Roth&#x27;s Great Petersburg Dictionary (1855–1875) — the foundational seven-volume Sanskrit–German lexicon of the 19th century and direct ancestor of Monier-Williams.">
 <meta name="twitter:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"Book","name":"Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch)","alternateName":"PW","inLanguage":"sa","author":{"@type":"Person","name":"Otto Böhtlingk &amp; Rudolph Roth"},"datePublished":"1855","publisher":{"@type":"Organization","name":"Cologne Digital Sanskrit Lexicon"},"url":"https://sanskrit-lexicon.github.io/PWG/","isAccessibleForFree":true,"license":"https://creativecommons.org/licenses/by-sa/4.0/"}
+{"@context":"https://schema.org","@type":"Book","name":"Sanskrit-Wörterbuch","alternateName":"PWG","inLanguage":"sa","publisher":{"@type":"Organization","name":"Cologne Digital Sanskrit Lexicon"},"url":"https://sanskrit-lexicon.github.io/PWG/","isAccessibleForFree":true,"license":"https://creativecommons.org/licenses/by-sa/4.0/"}
 </script>
 <style>
   :root { --ink:#1b2a38; --muted:#5a6b7a; --accent:#1f78b4; --bg:#f7f9fb; --card:#fff; --line:#e2e8ee; }
@@ -40,13 +40,11 @@
   .hero { background:linear-gradient(160deg,#1e2f40,#2d4e6e); color:#f4f7fa; padding:56px 0 48px; }
   .badge { display:inline-block; font-weight:700; letter-spacing:.08em; font-size:.8rem;
     background:rgba(255,255,255,.14); color:#cfe3f2; padding:.35rem .7rem; border-radius:999px; }
-  .hero h1 { font-family:Georgia,"Times New Roman",serif; font-size:2.1rem; line-height:1.2;
-    margin:.9rem 0 .5rem; }
+  .hero h1 { font-family:Georgia,"Times New Roman",serif; font-size:2.1rem; line-height:1.2; margin:.9rem 0 .5rem; }
   .hero .sub { color:#b7cddf; font-size:1.05rem; margin:0 0 1.2rem; }
   .hero p.desc { color:#dbe6f0; margin:0; max-width:62ch; }
   .cta { display:flex; flex-wrap:wrap; gap:.7rem; margin:1.6rem 0 0; }
-  .btn { display:inline-block; padding:.7rem 1.1rem; border-radius:8px; text-decoration:none;
-    font-weight:600; font-size:.95rem; }
+  .btn { display:inline-block; padding:.7rem 1.1rem; border-radius:8px; text-decoration:none; font-weight:600; font-size:.95rem; }
   .btn.primary { background:#4aa3df; color:#0b1b28; }
   .btn.ghost { background:rgba(255,255,255,.10); color:#eaf2f8; border:1px solid rgba(255,255,255,.25); }
   main { padding:40px 0 20px; }
@@ -66,26 +64,26 @@
 <body>
 <header class="top"><div class="wrap"><a href="https://sanskrit-lexicon.github.io/">← Cologne Digital Sanskrit Lexicon</a></div></header>
 <div class="hero"><div class="wrap">
-  <span class="badge">PW</span>
-  <h1>Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch)</h1>
-  <p class="sub">Otto Böhtlingk &amp; Rudolph Roth · St. Petersburg, 1855–1875</p>
-  <p class="desc">The “Großes Petersburger Wörterbuch” — Böhtlingk and Roth's seven-volume Sanskrit–German dictionary (St. Petersburg, 1855–1875), the foundational scholarly Sanskrit lexicon from which later dictionaries drew. Digitised, corrected, and openly published by the Cologne Digital Sanskrit Lexicon.</p>
+  <span class="badge">PWG</span>
+  <h1>Sanskrit-Wörterbuch</h1>
+  <p class="sub">Otto von Böhtlingk and Rudolph Roth · St. Petersburg, 1855–1875</p>
+  <p class="desc">Böhtlingk &amp; Roth's Great Petersburg Dictionary (1855–1875) — the foundational seven-volume Sanskrit–German lexicon of the 19th century and direct ancestor of Monier-Williams.</p>
   <div class="cta">
-    <a class="btn primary" href="https://www.sanskrit-lexicon.uni-koeln.de/scans/PWGScan/2013/web/webtc/indexcaller.php">Browse the dictionary →</a>
+    <a class="btn primary" href="https://www.sanskrit-lexicon.uni-koeln.de/scans/PWGScan/2020/web/webtc/indexcaller.php">Browse the dictionary →</a>
     <a class="btn ghost" href="https://github.com/sanskrit-lexicon/PWG">Source &amp; corrections (GitHub)</a>
     <a class="btn ghost" href="https://sanskrit-lexicon.github.io/">All dictionaries</a>
   </div>
 </div></div>
 <main><div class="wrap">
   <dl class="facts">
-    <div><dt>Abbreviation</dt><dd>PW</dd></div>
+    <div><dt>Abbreviation</dt><dd>PWG</dd></div>
     <div><dt>Direction</dt><dd>Sanskrit → German</dd></div>
     <div><dt>First published</dt><dd>1855–1875</dd></div>
     <div><dt>Digitised by</dt><dd>CDSL</dd></div>
   </dl>
   <section>
     <h2>About this edition</h2>
-    <p class="note">This is the digital home of the <strong>Sanskrit-Wörterbuch (Großes Petersburger Wörterbuch)</strong> (PW) within the
+    <p class="note">This is the digital home of the <strong>Sanskrit-Wörterbuch</strong> (PWG) within the
     <a href="https://www.sanskrit-lexicon.uni-koeln.de/">Cologne Digital Sanskrit Lexicon</a> (CDSL),
     a volunteer project that digitises, corrects, and openly publishes the foundational Sanskrit
     dictionaries as citable, reproducible data. Corrections are tracked as change files in this


### PR DESCRIPTION
The existing index.html (from an earlier codex/landing-page commit) mislabelled this dictionary as PW instead of PWG throughout (title, badge, JSON-LD alternateName, facts table) and pointed the Browse link at a stale 2013 scan mirror. This corrects it to match the org-wide gold-standard template (GRA/MD): badge PWG, verified working 2020 scan URL, correct Böhtlingk & Roth attribution. Also logs completion in .ai_state.md.