### PR TITLE
pagecolumn: PWG page/column co-location index + scan-verification sheet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ This repository does not currently publish versioned release notes. Entries use
 dated maintenance snapshots; keep upcoming work under [Unreleased] until it is
 ready for a dated entry.
 
+## [Unreleased]
+
+### Added
+- `pagecolumn/` — page/column co-location index. `pwg_page_index.py` derives, from the entry-start column (`<pc>`) in `csl-orig/v02/pwg/pwg.txt`, three views: column → entries that start in it (8,171 columns), physical page (2 columns merged) → entries (4,329 pages), and entry → its column(s)/page(s) (123,366 entries). `pwg_page_verify.py` emits a 70-row scan-verification anchor sheet so the derived `page = (column+1)//2` mapping can be checked against a scan (per-volume front-matter offset, column pairing). Derived `.tsv` views are git-ignored/regenerable; tools + the verification sheet are tracked.
+
 ## [1.0.0] - 2026-06-13
 
 ### Added

--- a/pagecolumn/.gitignore
+++ b/pagecolumn/.gitignore
@@ -1,0 +1,6 @@
+# Regenerable derived views (produced by pwg_page_index.py from csl-orig pwg.txt).
+# Not tracked, per the repo convention that script outputs are regenerated, not
+# committed. Run `python pwg_page_index.py` to (re)build them.
+pwg_columns.tsv
+pwg_pages.tsv
+pwg_entry_locations.tsv

--- a/pagecolumn/README.md
+++ b/pagecolumn/README.md
@@ -1,0 +1,88 @@
+# PWG page/column co-location index
+
+_Created: 12-07-2026 · Last updated: 12-07-2026_
+
+"Which PWG headwords shared a printed **column** (*Spalte*) or **page**?" —
+derived from the entry-start column that the source records in every header.
+
+Böhtlingk-Roth's PWG (7 vols, St. Petersburg 1855–1875) is printed **two columns
+per page**, and the canonical citation unit is the column. The source text
+[`csl-orig/v02/pwg/pwg.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt)
+records, in every entry header, the column that entry **starts** in:
+
+```
+<L>8<pc>1-0004<k1>aMSa<k2>aMSa<h>1
+     └──── volume 1, column 0004
+```
+
+## Tools
+
+| Script | Produces |
+|---|---|
+| [`pwg_page_index.py`](pwg_page_index.py) | the three co-location views below |
+| [`pwg_page_verify.py`](pwg_page_verify.py) | a scan-verification anchor sheet for the derived page numbers |
+
+```sh
+# from this directory; reads ../../csl-orig/v02/pwg/pwg.txt by default
+python pwg_page_index.py            # -> pwg_columns.tsv, pwg_pages.tsv, pwg_entry_locations.tsv
+python pwg_page_verify.py --per 10  # -> pwg_page_verification.tsv
+```
+
+The three `.tsv` views are **regenerable and git-ignored** (see
+[`.gitignore`](.gitignore)) — rebuild them with the command above. Only the tools
+and the small verification sheet are tracked.
+
+### 1. Column view — `pwg_columns.tsv` (8,171 columns)
+
+Each row is one printed column and the entries that **start** in it:
+
+```
+column   volume  page  n_entries  L_ids                          headwords
+1-0004   1       2     13         L8,L9,L10,L11,L12,...,L20       aMSa, aMSaka, aMSaka, ...
+```
+
+### 2. Page view — `pwg_pages.tsv` (4,329 pages)
+
+The two columns of a physical leaf, merged:
+
+```
+page      volume  columns          n_entries  L_ids       headwords
+1-p0002   1       1-0003+1-0004    17         L4,L5,...    a, a, afRin, aMSa, ...
+```
+
+### 3. Reverse view — `pwg_entry_locations.tsv` (123,366 entries)
+
+Where any single entry sits — start column, every column it occupies (long
+entries span into the next column via `[PageV-CCCC]` markers), and page(s):
+
+```
+L_id  headword  homonym  volume  start_column  page      all_columns             all_pages
+L3    a         3        1       1-0001        1-p0001    1-0001,1-0002,1-0003    1-p0001,1-p0002
+```
+
+## Caveats
+
+- Grouping is by where an entry **starts**. A long entry spanning into the next
+  column is counted at its start column only; its full span lives in the reverse
+  view's `all_columns` / `all_pages`.
+- **The physical page number is DERIVED, not stored** in the source:
+  `page = (column + 1) // 2` (2 columns per leaf, column 1 on page 1). The
+  **column** numbers are exact; the derived **page** number can be off by a
+  constant per-volume front-matter offset. PWG is cited by column and the scans
+  print column numbers, so [`pwg_page_verify.py`](pwg_page_verify.py) emits an
+  anchor sheet ([`pwg_page_verification.tsv`](pwg_page_verification.tsv), 70
+  rows: first/last leaf + 8 interior leaves per volume) with landmark headwords
+  in SLP1/IAST/Devanagari and blank `scan_leaf` / `cols_on_leaf` / `offset` /
+  `paired_ok` columns. If `offset` is constant per volume and `paired_ok` is all
+  `Y`, the derivation holds (shifted by that offset); any mid-volume drift is a
+  real defect.
+
+## Provenance
+
+Auto-derived from the csl-orig PWG source; no manual data. Ported from the
+equivalent tool in the
+[SanskritLexicography/RussianTranslation](https://github.com/gasyoun/SanskritLexicography/blob/master/RussianTranslation/src/pwg_page_index.py)
+pipeline, trimmed to the source-only derivation (the RussianTranslation copy also
+annotates that pipeline's translation cards).
+
+_Dr. Mārcis Gasūns_

--- a/pagecolumn/pwg_page_index.py
+++ b/pagecolumn/pwg_page_index.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""PWG page/column co-location index -- "which words shared a printed column / page".
+
+Boehtlingk-Roth's PWG (7 vols, St. Petersburg 1855-1875) is printed in TWO
+columns per page; the canonical citation unit is the column (Spalte). The source
+text csl-orig/v02/pwg/pwg.txt records, per entry header, the column an entry
+STARTS in:
+
+    <L>8<pc>1-0004<k1>aMSa<k2>aMSa<h>1
+         ^^^^^^ volume 1, column 0004
+
+This tool derives three views:
+
+  1. COLUMN view  -- column (<pc>) -> entries that start in it        (native unit)
+  2. PAGE view    -- physical page (2 columns merged) -> entries       (as in the book)
+  3. REVERSE view -- entry/headword -> its column(s), page(s), volume   (lookup)
+
+Page assumption: page_in_volume = (column + 1) // 2  (2 columns per page, column 1
+on page 1). Column numbering restarts per volume in the source; the physical
+page number is DERIVED, not stored, so verify against scans if the exact page
+label matters (a fixed front-matter offset would shift all page numbers by a
+constant within a volume). See pwg_page_verify.py for a scan-anchor sheet.
+
+Idempotent and deterministic (no Date.now / randomness).
+"""
+import argparse
+import collections
+import io
+import os
+import re
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+# L-id may be a float (Cologne supplement/Nachtrag records, e.g. 26305.290);
+# <h> homonym marker is optional.
+HEADER_RE = re.compile(r'^<L>([\d.]+)<pc>(\d+)-(\d+)<k1>(.*?)<k2>(.*?)(?:<h>(\d+))?\s*$')
+# internal column-break marker inside a long entry, e.g. [Page1-0002]
+PAGEBREAK_RE = re.compile(r'\[Page(\d+)-(\d+)\]')
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_SRC = os.path.join(HERE, '..', '..', 'csl-orig', 'v02', 'pwg', 'pwg.txt')
+
+
+class Entry:
+    __slots__ = ('L', 'vol', 'col', 'k1', 'k2', 'h', 'spans')
+
+    def __init__(self, L, vol, col, k1, k2, h):
+        self.L, self.vol, self.col, self.k1, self.k2, self.h = L, vol, col, k1, k2, h
+        self.spans = {(vol, col)}  # every (vol,col) this entry occupies
+
+
+def page_of(col):
+    """Physical page within a volume, 2 columns per page."""
+    return (col + 1) // 2
+
+
+def parse_source(path):
+    """Return list[Entry], filling .spans from embedded [PageV-CCCC] markers."""
+    entries = []
+    cur = None
+    with io.open(path, encoding='utf-8') as f:
+        for line in f:
+            m = HEADER_RE.match(line)
+            if m:
+                L, vol, col, k1, k2, h = m.groups()
+                cur = Entry(L, int(vol), int(col), k1, k2, h)
+                entries.append(cur)
+                continue
+            if cur is not None:
+                for pv, pc in PAGEBREAK_RE.findall(line):
+                    cur.spans.add((int(pv), int(pc)))
+    return entries
+
+
+def pc_str(vol, col):
+    return f'{vol}-{col:04d}'
+
+
+def write_column_view(entries, out):
+    """column -> entries that START there (native PWG citation unit)."""
+    by_col = collections.OrderedDict()
+    for e in entries:
+        by_col.setdefault((e.vol, e.col), []).append(e)
+    with io.open(out, 'w', encoding='utf-8') as f:
+        f.write('column\tvolume\tpage\tn_entries\tL_ids\theadwords\n')
+        for (vol, col), es in by_col.items():
+            f.write('\t'.join([
+                pc_str(vol, col), str(vol), str(page_of(col)), str(len(es)),
+                ','.join('L' + e.L for e in es),
+                ', '.join(e.k1 for e in es),
+            ]) + '\n')
+    return len(by_col)
+
+
+def write_page_view(entries, out):
+    """physical page -> entries whose START column falls on it (2 cols merged)."""
+    by_page = collections.OrderedDict()
+    for e in entries:
+        by_page.setdefault((e.vol, page_of(e.col)), []).append(e)
+    with io.open(out, 'w', encoding='utf-8') as f:
+        f.write('page\tvolume\tcolumns\tn_entries\tL_ids\theadwords\n')
+        for (vol, pg), es in by_page.items():
+            cols = sorted({e.col for e in es})
+            f.write('\t'.join([
+                f'{vol}-p{pg:04d}', str(vol),
+                '+'.join(pc_str(vol, c) for c in cols), str(len(es)),
+                ','.join('L' + e.L for e in es),
+                ', '.join(e.k1 for e in es),
+            ]) + '\n')
+    return len(by_page)
+
+
+def write_reverse_view(entries, out):
+    """entry -> where it is: start column, all occupied columns, page(s)."""
+    with io.open(out, 'w', encoding='utf-8') as f:
+        f.write('L_id\theadword\thomonym\tvolume\tstart_column\tpage'
+                '\tall_columns\tall_pages\n')
+        for e in entries:
+            spans = sorted(e.spans)
+            pages = sorted({(v, page_of(c)) for v, c in spans})
+            f.write('\t'.join([
+                'L' + e.L, e.k1, e.h or '', str(e.vol), pc_str(e.vol, e.col),
+                f'{e.vol}-p{page_of(e.col):04d}',
+                ','.join(pc_str(v, c) for v, c in spans),
+                ','.join(f'{v}-p{p:04d}' for v, p in pages),
+            ]) + '\n')
+    return len(entries)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--src', default=DEFAULT_SRC, help='pwg.txt source path')
+    ap.add_argument('--outdir', default=HERE, help='directory for the .tsv views')
+    args = ap.parse_args()
+
+    entries = parse_source(args.src)
+    print(f'parsed {len(entries)} PWG entries from {args.src}')
+
+    col_out = os.path.join(args.outdir, 'pwg_columns.tsv')
+    pg_out = os.path.join(args.outdir, 'pwg_pages.tsv')
+    rev_out = os.path.join(args.outdir, 'pwg_entry_locations.tsv')
+    nc = write_column_view(entries, col_out)
+    npg = write_page_view(entries, pg_out)
+    write_reverse_view(entries, rev_out)
+    print(f'  column view : {nc} columns   -> {col_out}')
+    print(f'  page view   : {npg} pages     -> {pg_out}')
+    print(f'  reverse view: {len(entries)} entries -> {rev_out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/pagecolumn/pwg_page_verification.tsv
+++ b/pagecolumn/pwg_page_verification.tsv
@@ -1,0 +1,71 @@
+volume	derived_page	left_pc	left_hw_slp1	left_hw_iast	left_hw_deva	right_pc	right_hw_slp1	right_hw_iast	right_hw_deva	scan_leaf	cols_on_leaf	offset	paired_ok
+1	1	1-0001	a	a	अ	1-0002	(continuation / no new entry)						
+1	62	1-0123	adarSa	adarśa	अदर्श	1-0124	adas	adas	अदस्				
+1	123	1-0245	antarAMsa	antarāṃsa	अन्तरांस	1-0246	antarAyaRa	antarāyaṇa	अन्तरायण				
+1	185	1-0369	amantu	amantu	अमन्तु	1-0370	amaracandra	amaracandra	अमरचन्द्र				
+1	247	1-0493	avasAyin	avasāyin	अवसायिन्	1-0494	avasTa	avastha	अवस्थ				
+1	309	1-0617	Atapavarzya	ātapavarṣya	आतपवर्ष्य	1-0618	AtiTya	ātithya	आतिथ्य				
+1	375	1-0749	AhiMsi	āhiṃsi	आहिंसि	1-0750	AhutIvfD	āhutīvṛdh	आहुतीवृध्				
+1	451	1-0901	utpAtaka	utpātaka	उत्पातक	1-0902	utpizwa	utpiṣṭa	उत्पिष्ट				
+1	511	1-1021	UruBinna	ūrubhinna	ऊरुभिन्न	1-1022	Urjay	ūrjay	ऊर्जय्				
+1	574	1-1147	aMSa	aṃśa	अंश	1-1148	(continuation / no new entry)						
+2	1	2-0001	ka	ka	क	2-0002	(continuation / no new entry)						
+2	67	2-0133	kardama	kardama	कर्दम	2-0134	karparIka	karparīka	कर्परीक				
+2	128	2-0255	kAlaniryAsa	kālaniryāsa	कालनिर्यास	2-0256	kAlapeSI	kālapeśī	कालपेशी				
+2	183	2-0365	kuSacIra	kuśacīra	कुशचीर	2-0366	(continuation / no new entry)						
+2	239	2-0477	kranda	kranda	क्रन्द	2-0478	(continuation / no new entry)						
+2	300	2-0599	Kanana	khanana	खनन	2-0600	KaBrAnti	khabhrānti	खभ्रान्ति				
+2	368	2-0735	gAnDAraka	gāndhāraka	गान्धारक	2-0736	gAMmanya	gāṃmanya	गांमन्य				
+2	430	2-0859	grAmabAlajana	grāmabālajana	ग्रामबालजन	2-0860	grAmIRa	grāmīṇa	ग्रामीण				
+2	493	2-0985	cANgerI	cāṅgerī	चाङ्गेरी	2-0986	cARakyamUlaka	cāṇakyamūlaka	चाणक्यमूलक				
+2	552	2-1103	uttarIya	uttarīya	उत्तरीय	2-1104	(continuation / no new entry)						
+3	1	3-0001	ja	ja	ज	3-0002	jaMs	jaṃs	जंस्				
+3	55	3-0109	jImUta	jīmūta	जीमूत	3-0110	jIraka	jīraka	जीरक				
+3	112	3-0223	(continuation / no new entry)			3-0224	tanuka	tanuka	तनुक				
+3	169	3-0337	tilaka	tilaka	तिलक	3-0338	tilakaka	tilakaka	तिलकक				
+3	220	3-0439	triBajIvA	tribhajīvā	त्रिभजीवा	3-0440	trimantu	trimantu	त्रिमन्तु				
+3	273	3-0545	dalakomala	dalakomala	दलकोमल	3-0546	dalAQya	dalāḍhya	दलाढ्य				
+3	334	3-0667	dunduBika	dundubhika	दुन्दुभिक	3-0668	dura	dura	दुर				
+3	387	3-0773	dEvaka	daivaka	दैवक	3-0774	dEvatapati	daivatapati	दैवतपति				
+3	442	3-0883	(continuation / no new entry)			3-0884	Darmaka	dharmaka	धर्मक				
+3	508	3-1015	truw	truṭ	त्रुट्	3-1016	(continuation / no new entry)						
+4	1	4-0001	na	na	न	4-0002	(continuation / no new entry)						
+4	69	4-0137	nigadita	nigadita	निगदित	4-0138	nigalana	nigalana	निगलन				
+4	133	4-0265	nihnuti	nihnuti	निह्नुति	4-0266	(continuation / no new entry)						
+4	208	4-0415	pattraka	pattraka	पत्त्रक	4-0416	pattrapuzpaka	pattrapuṣpaka	पत्त्रपुष्पक				
+4	283	4-0565	paruzAkzara	paruṣākṣara	परुषाक्षर	4-0566	pare	pare	परे				
+4	349	4-0697	pASaka	pāśaka	पाशक	4-0698	pASI	pāśī	पाशी				
+4	415	4-0829	pUjaka	pūjaka	पूजक	4-0830	pUjanIya	pūjanīya	पूजनीय				
+4	479	4-0957	pratinava	pratinava	प्रतिनव	4-0958	pratinisarga	pratinisarga	प्रतिनिसर्ग				
+4	543	4-1085	praSaMsin	praśaṃsin	प्रशंसिन्	4-1086	praSasta	praśasta	प्रशस्त				
+4	610	4-1219	pad	pad	पद्	4-1220	(continuation / no new entry)						
+5	1	5-0001	ba	ba	ब	5-0002	baqapilA	baḍapilā	बडपिला				
+5	98	5-0195	Badraka	bhadraka	भद्रक	5-0196	BadrakarRikA	bhadrakarṇikā	भद्रकर्णिका				
+5	204	5-0407	BrAj	bhrāj	भ्राज्	5-0408	BrAjizRu	bhrājiṣṇu	भ्राजिष्णु				
+5	304	5-0607	masUraka	masūraka	मसूरक	5-0608	mastakajvara	mastakajvara	मस्तकज्वर				
+5	394	5-0787	miSralawakana	miśralaṭakana	मिश्रलटकन	5-0788	miz	miṣ	मिष्				
+5	489	5-0977	aDvanya	adhvanya	अध्वन्य	5-0978	anaNgapura	anaṅgapura	अनङ्गपुर				
+5	577	5-1153	uktapratyukta	uktapratyukta	उक्तप्रत्युक्त	5-1154	ugra	ugra	उग्र				
+5	664	5-1327	kesaramAlA	kesaramālā	केसरमाला	5-1328	kEvartIya	kaivartīya	कैवर्तीय				
+5	752	5-1503	durvaca	durvaca	दुर्वच	5-1504	duSCinna	duśchinna	दुश्छिन्न				
+5	839	5-1677	mokzay	mokṣay	मोक्षय्	5-1678	mOrva	maurva	मौर्व				
+6	1	6-0001	ya	ya	य	6-0002	(continuation / no new entry)						
+6	96	6-0191	yogAYjana	yogāñjana	योगाञ्जन	6-0192	yoginIjAlaSambara	yoginījālaśambara	योगिनीजालशम्बर				
+6	176	6-0351	rAvaRa	rāvaṇa	रावण	6-0352	rASaBa	rāśabha	राशभ				
+6	263	6-0525	lAkuca	lākuca	लाकुच	6-0526	lAG	lāgh	लाघ्				
+6	345	6-0689	vappawadevI	vappaṭadevī	वप्पटदेवी	6-0690	vama	vama	वम				
+6	452	6-0903	vAwIdIrGa	vāṭīdīrgha	वाटीदीर्घ	6-0904	vARa	vāṇa	वाण				
+6	527	6-1053	vidagDa	vidagdha	विदग्ध	6-1054	vidadaSva	vidadaśva	विददश्व				
+6	606	6-1211	viSArAdeman	viśārādeman	विशारादेमन्	6-1212	viSAlagrAma	viśālagrāma	विशालग्राम				
+6	678	6-1355	vetasa	vetasa	वेतस	6-1356	vetAlajananI	vetālajananī	वेतालजननी				
+6	756	6-1511	yaTAtaTam	yathātatham	यथातथम्	6-1512	(continuation / no new entry)						
+7	1	7-0001	Sa	śa	श	7-0002	(continuation / no new entry)						
+7	96	7-0191	Siras	śiras	शिरस्	7-0192	Sirasa	śirasa	शिरस				
+7	199	7-0397	Srotas	śrotas	श्रोतस्	7-0398	Srotravant	śrotravant	श्रोत्रवन्त्				
+7	296	7-0591	satsaNga	satsaṅga	सत्सङ्ग	7-0592	(continuation / no new entry)						
+7	402	7-0803	sarja	sarja	सर्ज	7-0804	sarjaniryAsaka	sarjaniryāsaka	सर्जनिर्यासक				
+7	499	7-0997	sidDikara	siddhikara	सिद्धिकर	7-0998	sidDiBUmi	siddhibhūmi	सिद्धिभूमि				
+7	593	7-1185	setuka	setuka	सेतुक	7-1186	setubanDana	setubandhana	सेतुबन्धन				
+7	704	7-1407	(continuation / no new entry)			7-1408	srukka	srukka	स्रुक्क				
+7	818	7-1635	(continuation / no new entry)			7-1636	hu	hu	हु				
+7	911	7-1821	sOna	sauna	सौन	7-1822	sPowaka	sphoṭaka	स्फोटक				

--- a/pagecolumn/pwg_page_verify.py
+++ b/pagecolumn/pwg_page_verify.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""Build a scan-verification anchor sheet for the DERIVED PWG page numbers.
+
+pwg_page_index.py derives a physical page from a column via
+    page = (column + 1) // 2   (2 columns per leaf, column 1 on page 1)
+That derivation is NOT stored in the source and can be off by a constant
+per-volume front-matter offset (or, worse, the (2k-1, 2k) pairing could be
+shifted). PWG is cited by COLUMN (Spalte) and the scans print column numbers,
+so a scan verifies the PAIRING/OFFSET, not a page label.
+
+This tool emits anchor rows a human takes to the scan. For each anchor
+(physical page P in volume V) it names the two columns the formula assigns to
+that leaf -- left = 2P-1, right = 2P -- and, for each, the first headword that
+STARTS in that column (the landmark to locate on the scan), in SLP1 / IAST /
+Devanagari. The verifier fills:
+
+    scan_leaf        page/leaf label actually printed on the scan (blank if the
+                     book labels only columns -- then just confirm the pairing)
+    cols_on_leaf     the two column numbers actually printed together on that leaf
+    offset           scan_leaf - derived_page  (should be constant within a volume)
+    paired_ok        Y if the two columns above == (2P-1, 2P), else N
+
+If offset is constant per volume and paired_ok is all Y, the derivation holds
+(shifted by that offset). Any drift is a real defect to chase.
+
+Anchors per volume: first leaf, last leaf, and evenly spaced interior leaves
+(--per, default 10). IAST/Devanagari landmarks require indic_transliteration;
+without it those two columns are left blank (SLP1 is always emitted).
+Deterministic; no Date.now / randomness.
+"""
+import argparse
+import collections
+import io
+import os
+import sys
+
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
+try:
+    from indic_transliteration import sanscript
+    def iast(x): return sanscript.transliterate(x, sanscript.SLP1, sanscript.IAST)
+    def deva(x): return sanscript.transliterate(x, sanscript.SLP1, sanscript.DEVANAGARI)
+except Exception:  # pragma: no cover - lib optional
+    def iast(x): return ''
+    def deva(x): return ''
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_COLS = os.path.join(HERE, 'pwg_columns.tsv')
+
+
+def load_columns(path):
+    """(vol, col) -> first headword (SLP1) that starts in that column."""
+    first = {}
+    per_vol = collections.defaultdict(list)
+    with io.open(path, encoding='utf-8') as f:
+        next(f)
+        for line in f:
+            p = line.rstrip('\n').split('\t')
+            pc, vol = p[0], int(p[1])
+            col = int(pc.split('-')[1])
+            heads = p[5].split(', ') if len(p) > 5 else []
+            if (vol, col) not in first:
+                first[(vol, col)] = heads[0] if heads else ''
+                per_vol[vol].append(col)
+    for v in per_vol:
+        per_vol[v].sort()
+    return first, per_vol
+
+
+def anchor_pages(cols_present, per):
+    """Choose ~`per` physical-page anchors spread across a volume's columns."""
+    if not cols_present:
+        return []
+    pages = sorted({(c + 1) // 2 for c in cols_present})
+    if len(pages) <= per:
+        return pages
+    step = (len(pages) - 1) / (per - 1)
+    idx = sorted({round(i * step) for i in range(per)})
+    return [pages[i] for i in idx]
+
+
+def landmark(first, vol, col):
+    hw = first.get((vol, col))
+    if not hw:
+        return '(continuation / no new entry)', '', ''
+    return hw, iast(hw), deva(hw)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--cols', default=DEFAULT_COLS, help='pwg_columns.tsv path')
+    ap.add_argument('--per', type=int, default=10, help='anchor leaves per volume')
+    ap.add_argument('--out', default=os.path.join(HERE, 'pwg_page_verification.tsv'),
+                    help='fillable anchor sheet (TSV)')
+    args = ap.parse_args()
+
+    first, per_vol = load_columns(args.cols)
+
+    rows = []
+    for vol in sorted(per_vol):
+        for pg in anchor_pages(per_vol[vol], args.per):
+            lcol, rcol = 2 * pg - 1, 2 * pg
+            l_slp, l_iast, l_deva = landmark(first, vol, lcol)
+            r_slp, r_iast, r_deva = landmark(first, vol, rcol)
+            rows.append([
+                vol, pg,
+                f'{vol}-{lcol:04d}', l_slp, l_iast, l_deva,
+                f'{vol}-{rcol:04d}', r_slp, r_iast, r_deva,
+                '', '', '', '',  # scan_leaf, cols_on_leaf, offset, paired_ok
+            ])
+
+    header = ['volume', 'derived_page',
+              'left_pc', 'left_hw_slp1', 'left_hw_iast', 'left_hw_deva',
+              'right_pc', 'right_hw_slp1', 'right_hw_iast', 'right_hw_deva',
+              'scan_leaf', 'cols_on_leaf', 'offset', 'paired_ok']
+    with io.open(args.out, 'w', encoding='utf-8') as f:
+        f.write('\t'.join(header) + '\n')
+        for r in rows:
+            f.write('\t'.join(str(x) for x in r) + '\n')
+    print(f'wrote {len(rows)} anchor rows across {len(per_vol)} volumes -> {args.out}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Adds `pagecolumn/` — a tool that answers **"which PWG headwords shared a printed column (Spalte) or page?"**, derived entirely from the entry-start column (`<pc>`) recorded in every header of [csl-orig/v02/pwg/pwg.txt](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/pwg/pwg.txt). No manual data.

## Tools

- [`pwg_page_index.py`](https://github.com/sanskrit-lexicon/PWG/blob/pagecolumn-colocation-index/pagecolumn/pwg_page_index.py) — three views: **column → entries** (8,171 columns), **physical page (2 columns merged) → entries** (4,329 pages), **entry → its column(s)/page(s)** (123,366 entries).
- [`pwg_page_verify.py`](https://github.com/sanskrit-lexicon/PWG/blob/pagecolumn-colocation-index/pagecolumn/pwg_page_verify.py) — a 70-row scan-verification anchor sheet.

## Page number is derived, not stored

PWG prints 2 columns/page; the **column** numbers in the source are exact, but the physical **page** is derived as `page = (column+1)//2` and can be off by a constant per-volume front-matter offset. PWG is cited by column and the scans print column numbers, so [`pwg_page_verification.tsv`](https://github.com/sanskrit-lexicon/PWG/blob/pagecolumn-colocation-index/pagecolumn/pwg_page_verification.tsv) gives landmark headwords (SLP1/IAST/Devanagari) per anchor leaf with blank `scan_leaf`/`cols_on_leaf`/`offset`/`paired_ok` columns to fill against a scan. Constant offset per volume ⇒ derivation holds; drift ⇒ real defect.

## Footprint

Minimal diff: two tools, a README, the small verification sheet, one changelog entry. The three large derived `.tsv` views are **git-ignored/regenerable** (`python pwg_page_index.py`), per the repo convention that script outputs aren't tracked. Ruff-clean; `py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)