### PR TITLE
docs(prefaces): methods note + cite path for front-matter OCR (H1558)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,23 @@
 cff-version: 1.2.0
 type: dataset
 title: Böhtlingk and Roth Grosses Petersburger Wörterbuch
-message: If you use this dataset, please cite both the digital edition and the printed source it digitises.
+message: >-
+  If you use the dictionary digitisation, cite preferred-citation (printed PWG)
+  and the Cologne Digital Sanskrit Lexicon project. If you use the front-matter
+  OCR editions under prefaces/ (DE transcription + EN/RU translations), also
+  cite that package as described in prefaces/METHODS.md (scan source, OCR
+  engines A/B, translation policy, BibTeX). Zenodo DOI for the OCR package may
+  be added when a release is cut.
 license: CC-BY-SA-4.0
 repository-code: https://github.com/sanskrit-lexicon/PWG
+url: https://sanskrit-lexicon.github.io/PWG/
 date-released: 1855-01-01
 version: 1.0.0
+abstract: >-
+  Scripts and data for correcting and enriching the PWG (Sanskrit-Wörterbuch,
+  Böhtlingk & Roth, 1855–1875) in the Cologne Digital Sanskrit Lexicon, plus
+  OCR'd front matter (27 pages: title pages, forewords, abbreviation lists,
+  addenda) with English and Russian translations under prefaces/.
 keywords:
   - sanskrit
   - lexicon
@@ -13,9 +25,26 @@ keywords:
   - cologne-digital-sanskrit-lexicon
   - dictionary
   - skt-ger
+  - ocr
+  - front-matter
+  - prefaces
 authors:
   - name: "Cologne Digital Sanskrit Lexicon project contributors"
     website: https://www.sanskrit-lexicon.uni-koeln.de/
+  - family-names: "Gasuns"
+    given-names: "Marcis"
+    orcid: "https://orcid.org/0000-0003-4513-884X"
+    website: https://github.com/gasyoun
+identifiers:
+  - type: url
+    value: https://github.com/sanskrit-lexicon/PWG/tree/main/prefaces
+    description: Front-matter OCR package (DE/EN/RU)
+  - type: url
+    value: https://github.com/sanskrit-lexicon/PWG/blob/main/prefaces/METHODS.md
+    description: Methods note and how to cite the front-matter OCR
+  - type: url
+    value: https://sanskrit-lexicon.github.io/PWG/prefaces/pwgpref_all.en.md
+    description: Consolidated English front-matter edition (GitHub Pages)
 preferred-citation:
   type: book
   title: Böhtlingk and Roth Grosses Petersburger Wörterbuch
@@ -23,4 +52,4 @@ preferred-citation:
   authors:
     - family-names: "Böhtlingk"
     - family-names: "Roth"
-  notes: "The grand Petersburger 1855-1875"
+  notes: "The grand Petersburger 1855-1875. For the 2026 front-matter OCR (prefaces/), see prefaces/METHODS.md."

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,11 @@ ready for a dated entry.
 ### Added
 - `pagecolumn/` — page/column co-location index. `pwg_page_index.py` derives, from the entry-start column (`<pc>`) in `csl-orig/v02/pwg/pwg.txt`, three views: column → entries that start in it (8,171 columns), physical page (2 columns merged) → entries (4,329 pages), and entry → its column(s)/page(s) (123,366 entries). `pwg_page_verify.py` emits a 70-row scan-verification anchor sheet so the derived `page = (column+1)//2` mapping can be checked against a scan (per-volume front-matter offset, column pairing). Derived `.tsv` views are git-ignored/regenerable; tools + the verification sheet are tracked.
 
+## [Unreleased]
+
+### Added
+- Front-matter OCR methods note and cite path: [`prefaces/METHODS.md`](prefaces/METHODS.md) (scan source, engines A/B, translation policy, BibTeX); root [`CITATION.cff`](CITATION.cff) expanded with OCR identifiers and dual-cite message (H1558).
+
 ## [1.0.0] - 2026-06-13
 
 ### Added

--- a/prefaces/METHODS.md
+++ b/prefaces/METHODS.md
@@ -1,0 +1,142 @@
+# PWG front-matter OCR — methods and citation
+
+_Created: 24-07-2026 · Last updated: 24-07-2026_
+
+This note documents how the **PWG** (`prefaces/`) front-matter editions were produced so they can be treated as citable research objects. Page inventory and reading notes live in [README.md](README.md). Public index: [OCR'd prefaces](https://sanskrit-lexicon.github.io/csl-guides/dictionaries/ocr-prefaces). Operator manual: [Preface OCR pipeline](https://sanskrit-lexicon.github.io/csl-guides/dictionaries/preface-ocr-pipeline).
+
+---
+
+## What this is
+
+Faithful Markdown OCR of the **Vorspann** of the *Sanskrit-Wörterbuch* (Otto Böhtlingk & Rudolph Roth, *Großes Petersburger Wörterbuch*), St. Petersburg, Kaiserliche Akademie der Wissenschaften, **1855–1875**, with English and Russian translations.
+
+| Item | Value |
+|---|---|
+| Dictionary code | **PWG** |
+| Repo | [sanskrit-lexicon/PWG](https://github.com/sanskrit-lexicon/PWG) |
+| Source language | German (19th-c. orthography preserved) |
+| Page count | **27** scan pages |
+| Languages shipped | DE (source) · EN · RU |
+| Consolidated editions | [pwgpref_all.de.md](pwgpref_all.de.md) · [pwgpref_all.en.md](pwgpref_all.en.md) · [pwgpref_all.ru.md](pwgpref_all.ru.md) |
+| GitHub Pages (EN) | https://sanskrit-lexicon.github.io/PWG/prefaces/pwgpref_all.en.md |
+| Tracking notice | [PWG#210](https://github.com/sanskrit-lexicon/PWG/issues/210) |
+
+---
+
+## Scan source
+
+| Field | Value |
+|---|---|
+| Cologne index | [pwgpref.html](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref.html) |
+| Per-page HTML | `…/prefaces/pwgpref/pwgprefNN.html` (NN = 01–27) |
+| Image base | `https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/_images/` |
+| Local mirrors | [scans/](scans/) (27 PNGs, e.g. `pwg1-0000--01.png` …) |
+| Page order | **csldoc toctree order** (not lexical sort of image filenames; PWG had filename swaps between some Foreword/Abbreviations pages) |
+
+Each per-page file carries YAML: `source_scan`, `source_page`, `volume`, `source_url`.
+
+### Page inventory (summary)
+
+| Vol. | Sections (NN) |
+|---:|---|
+| 1 | Title; Foreword 1–5; Abbreviations 1–5 (`01`–`11`) |
+| 2 | Title; Addenda vol. 1–2; Foreword; Abbreviations additions (`12`–`16`) |
+| 3 | Title; Foreword; Abbreviations additions (`17`–`19`) |
+| 4 | Title; Foreword (`20`–`21`) |
+| 5 | Title; Foreword parts 1–2 (`22`–`24`) |
+| 6 | Title (`25`) |
+| 7 | Title; Foreword final (`26`–`27`) |
+
+Full table with links: [README.md § Contents](README.md#contents).
+
+---
+
+## OCR policy (engines A / B)
+
+Production skill: **`/cologne-preface-ocr`** (Claude Code command; Codex twin available).
+
+| Engine | Role | Mechanism |
+|---|---|---|
+| **A — Vision band OCR** | **Author** of canonical `pwgprefNN.md` | Native-resolution column/band crops (longest side ≲ ~1900 px); vision model → faithful transcription. Never OCR a full downsampled page (fabricates text). |
+| **B — Tesseract crop-then-OCR** | **Audit only** on CDSL | Optional comparison layer; **must not** auto-overwrite Engine A. Useful for coverage/layout flags. |
+
+Hard rule: Engine B text is never promoted into canonical pages without a human/vision re-check of the scan band. Bake-off evidence (A as gold): [PD COMPARISON_PWG_OCR_A_VS_B.md](https://github.com/sanskrit-lexicon/PD/blob/main/COMPARISON_PWG_OCR_A_VS_B.md).
+
+PD’s `feat/ocr-v2-pipeline` is a **sibling** pipeline for Deccan College PDF front matter — not a second author for CDSL PWG pages.
+
+### Uncertainty markers
+
+| Marker | Meaning |
+|---|---|
+| `[?]` | Uncertain reading (glyph/word) |
+| `[illegible]` | Unreadable locus on the scan |
+
+Digitizer running headers and the Cologne “Institute of Indology & Tamil Studies …” stamp/footer are **omitted** (not part of the printed book).
+
+---
+
+## Translation policy
+
+- Source `.md` keeps 19th-c. German orthography (*Theil, Litteratur, dass, citirt, …*) and Böhtlingk–Roth romanization / Devanāgarī **as printed**.
+- `.en.md` / `.ru.md` translate German prose scaffolding only.
+- Left **verbatim** in all languages: Sanskrit forms, personal names, work titles, bibliographic abbreviation keys, years, and reference numbers.
+- On abbreviation lists and addenda, only headings, notes, and glosses such as “instead of … read …” are rendered; keys and titles stay as printed.
+
+---
+
+## Regeneration
+
+Consolidated single-file editions are built from per-page files:
+
+```text
+cd prefaces
+python build_combined.py
+```
+
+Edit `pwgprefNN.md` / `.en.md` / `.ru.md`, then re-run. Do not hand-edit `pwgpref_all.*` except via the builder.
+
+---
+
+## Provenance
+
+| Field | Value |
+|---|---|
+| Workflow | `/cologne-preface-ocr` (vision author; optional Tesseract audit) |
+| First landed (approx.) | 2026 H1 (see repo history for `prefaces/`) |
+| Methods note | 24-07-2026 (H1558) |
+| Agent attribution | Production path = Claude Code vision skill (default tier Fable 5 / Opus 4.8 fallback); commits may land under the maintainer account after agent runs — see [preface-ocr-pipeline](https://sanskrit-lexicon.github.io/csl-guides/dictionaries/preface-ocr-pipeline) |
+| License of this repo’s digital work | CC-BY-SA-4.0 (see root [CITATION.cff](../CITATION.cff) and [LICENSE](../LICENSE)) |
+| Printed source | Public-domain 19th-c. imprint; always cite the book as well as the OCR |
+
+---
+
+## How to cite
+
+Cite **two layers** when you use these files: (1) the printed PWG, (2) this digital front-matter OCR.
+
+### 1. Printed source (preferred-citation in CITATION.cff)
+
+Böhtlingk, Otto, and Rudolph Roth. *Sanskrit-Wörterbuch*. St. Petersburg: Kaiserliche Akademie der Wissenschaften, 1855–1875.
+
+### 2. Front-matter OCR edition (this directory)
+
+Gasūns, Mārcis, and Cologne Digital Sanskrit Lexicon project contributors. 2026. “PWG front-matter OCR (title pages, forewords, abbreviation lists, addenda): German transcription with English and Russian translations.” In *sanskrit-lexicon/PWG*, `prefaces/`. https://github.com/sanskrit-lexicon/PWG/tree/main/prefaces · methods: https://github.com/sanskrit-lexicon/PWG/blob/main/prefaces/METHODS.md · English consolidated: https://sanskrit-lexicon.github.io/PWG/prefaces/pwgpref_all.en.md
+
+#### BibTeX
+
+```bibtex
+@misc{pwg_pref_ocr_2026,
+  author       = {Gasūns, Mārcis and Cologne Digital Sanskrit Lexicon project contributors},
+  title        = {{PWG} front-matter {OCR}: German transcription with English and Russian translations},
+  year         = {2026},
+  howpublished = {GitHub repository \texttt{sanskrit-lexicon/PWG}, directory \texttt{prefaces/}},
+  url          = {https://github.com/sanskrit-lexicon/PWG/tree/main/prefaces},
+  note         = {Methods: https://github.com/sanskrit-lexicon/PWG/blob/main/prefaces/METHODS.md. Scan source: Cologne csldoc pwgpref. License of digital edition: CC-BY-SA-4.0.}
+}
+```
+
+Root [CITATION.cff](../CITATION.cff) points at both the printed book (`preferred-citation`) and this OCR package (`message` + `identifiers`). A Zenodo DOI may be added later when a release is cut; until then use the GitHub / Pages URLs above.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/prefaces/README.md
+++ b/prefaces/README.md
@@ -2,6 +2,8 @@
 
 OCR transcriptions **and English + Russian translations** of the front matter of the **Sanskrit-Wörterbuch** (Otto Böhtlingk & Rudolph Roth, *Großes Petersburger Wörterbuch*), St. Petersburg, Kaiserliche Akademie der Wissenschaften, 1855–1875.
 
+**Methods and how to cite:** [METHODS.md](METHODS.md) (scan source, page inventory, OCR engines A/B, translation policy, BibTeX). Root cite metadata: [CITATION.cff](../CITATION.cff).
+
 Source: the Cologne digitization scan pages under
 [pwgpref.html](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref.html).
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ they share source material and markup conventions.
 | [`verbs01a/`](https://github.com/sanskrit-lexicon/PWG/tree/main/verbs01a) | Verb identification correlated with Monier-Williams (MW) dictionary (begun Mar 2020) |
 | [`RussianWords/`](https://github.com/sanskrit-lexicon/PWG/tree/main/RussianWords) | Russian etymologies in PWG |
 | [`pwgheader/`](https://github.com/sanskrit-lexicon/PWG/tree/main/pwgheader) | Volume and header metadata |
-| [`prefaces/`](https://github.com/sanskrit-lexicon/PWG/tree/main/prefaces) | OCR'd front matter (titles, forewords, abbreviation lists, addenda) with EN/RU translations and consolidated single-file editions |
+| [`prefaces/`](https://github.com/sanskrit-lexicon/PWG/tree/main/prefaces) | OCR'd front matter (titles, forewords, abbreviation lists, addenda) with EN/RU translations and consolidated single-file editions; methods + cite block in [`prefaces/METHODS.md`](https://github.com/sanskrit-lexicon/PWG/blob/main/prefaces/METHODS.md) |
 | [`misc/`](https://github.com/sanskrit-lexicon/PWG/tree/main/misc) | Accent display, encoding conversion, and other utilities |
 
 > An experimental LLM-assisted pilot (translation / literary-source targeting /


### PR DESCRIPTION
## Summary

Makes the existing PWG front-matter OCR package **citable** with an explicit methods note (no re-OCR).

- Add prefaces/METHODS.md: scan URL, page inventory (27), engines A (vision author) / B (Tesseract audit-only), translation policy, uncertainty markers, build_combined.py regenerate, provenance, APA + BibTeX cite blocks
- Expand root CITATION.cff: dual-cite message (printed book + OCR package), abstract, OCR keywords, ORCID author row, URL identifiers for prefaces/, METHODS, Pages EN consolidated
- Cross-link from prefaces/README.md and root readme.md; changelog [Unreleased] bullet

Handoff: H1558. Tracking: #210.

## Test plan

- [ ] METHODS opens and links resolve
- [ ] CITATION.cff still valid YAML / cff
- [ ] No content changes under per-page pwgpref* files