### PR TITLE
fix(prefaces): page-boundary OCR omissions (H1721)

### DIFF
--- a/prefaces/pwgpref07.en.md
+++ b/prefaces/pwgpref07.en.md
@@ -15,7 +15,7 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Ms.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, a scholiast of the Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Cited according to the 8 Pańḱikâ (an external division, into which the 40 Adhjâja formed on factual considerations are split) and the chapter numbers running continuously within the Pańḱikâ. Ms. Sâjana's Commentary thereto. Ms.

--- a/prefaces/pwgpref07.md
+++ b/prefaces/pwgpref07.md
@@ -13,7 +13,7 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Hdschr.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, ein Scholiast des Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Citirt nach den 8 Pańḱikâ (einer äusseren Abtheilung, in welche die 40 nach sachlichen Rücksichten gebildeten Adhjâja zerlegt sind) und den innerhalb der Pańḱikâ durchlaufenden Kapitelzahlen. Hdschr. Sâjana's Commentar dazu. Hdschr.

--- a/prefaces/pwgpref07.ru.md
+++ b/prefaces/pwgpref07.ru.md
@@ -15,7 +15,7 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Рук.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, схолиаст Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Цитируется по 8 Pańḱikâ (внешнему разделению, на которое разбиты 40 Adhjâja, образованных по содержательным соображениям) и по номерам глав, идущим сквозной нумерацией внутри Pańḱikâ. Рук. Комментарий Sâjana к нему. Рук.

--- a/prefaces/pwgpref09.en.md
+++ b/prefaces/pwgpref09.en.md
@@ -9,8 +9,10 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 # Explanation of the Abbreviations.
 
-[Paris 1829.] (Continuation of the preceding entry)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = Jâǵńavalkja's law book. Sanskrit and German edited by Dr. Adolph Friedrich Stenzler. Berlin and London 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, see Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.

--- a/prefaces/pwgpref09.md
+++ b/prefaces/pwgpref09.md
@@ -7,8 +7,10 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 # Erklärung der Abkürzungen.
 
-[Paris 1829.] (Fortsetzung des vorhergehenden Eintrags)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = Jâǵńavalkja's Gesetzbuch. Sanskrit und Deutsch herausgegeben von Dr. Adolph Friedrich Stenzler. Berlin und London 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, s. Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.

--- a/prefaces/pwgpref09.ru.md
+++ b/prefaces/pwgpref09.ru.md
@@ -9,8 +9,10 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 # Объяснение сокращений.
 
-[Paris 1829.] (Продолжение предыдущей записи)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = законодательный свод Jâǵńavalkja. Издано на санскрите и немецком д-ром Adolph Friedrich Stenzler. Берлин и Лондон, 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, см. Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.

--- a/prefaces/pwgpref19.en.md
+++ b/prefaces/pwgpref19.en.md
@@ -11,6 +11,8 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 Explanation of the abbreviations newly added in the third Part.
 
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, in manuscript in the Paris Library, after communications from A. Schiefner.
+
 DAŚABH. = DAÇABHŪMIÇVARA, in manuscript in the Paris Library, after communications from A. Schiefner.
 
 GOLD. MĀN. = MĀNAVA-KALPA-SŪTRA; being a portion of this ancient work on Vaidik rites, together with the Commentary of KUMĀRILA-SVĀMIN. With a preface by THEODOR GOLDSTÜCKER. London 1861.

--- a/prefaces/pwgpref19.md
+++ b/prefaces/pwgpref19.md
@@ -9,6 +9,8 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 Erklärung der im dritten Theile neu hinzugekommenen Abkürzungen.
 
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, handschriftlich in der Pariser Bibliothek, nach Mittheilungen von A. Schiefner.
+
 DAŚABH. = DAÇABHŪMIÇVARA, handschriftlich in der Pariser Bibliothek, nach Mittheilungen von A. Schiefner.
 
 GOLD. MĀN. = MĀNAVA-KALPA-SŪTRA; being a portion of this ancient work on Vaidik rites, together with the Commentary of KUMĀRILA-SVĀMIN. With a preface by THEODOR GOLDSTÜCKER. London 1861.

--- a/prefaces/pwgpref19.ru.md
+++ b/prefaces/pwgpref19.ru.md
@@ -11,6 +11,8 @@ source_url: https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dict
 
 Объяснение сокращений, вновь добавленных в третьем томе.
 
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, в рукописи в Парижской библиотеке, по сообщениям А. Шифнера.
+
 DAŚABH. = DAÇABHŪMIÇVARA, в рукописи в Парижской библиотеке, по сообщениям А. Шифнера.
 
 GOLD. MĀN. = MĀNAVA-KALPA-SŪTRA; being a portion of this ancient work on Vaidik rites, together with the Commentary of KUMĀRILA-SVĀMIN. With a preface by THEODOR GOLDSTÜCKER. London 1861.

--- a/prefaces/pwgpref_all.de.md
+++ b/prefaces/pwgpref_all.de.md
@@ -209,7 +209,7 @@ Mancher Mangel des Wörterbuchs wird seine Entschuldigung darin finden dürfen, 
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Hdschr.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, ein Scholiast des Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Citirt nach den 8 Pańḱikâ (einer äusseren Abtheilung, in welche die 40 nach sachlichen Rücksichten gebildeten Adhjâja zerlegt sind) und den innerhalb der Pańḱikâ durchlaufenden Kapitelzahlen. Hdschr. Sâjana's Commentar dazu. Hdschr.
@@ -355,8 +355,10 @@ II
 
 <sub>Quelle (Scan): [pwg1-0000--09.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref09.html)</sub>
 
-[Paris 1829.] (Fortsetzung des vorhergehenden Eintrags)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = Jâǵńavalkja's Gesetzbuch. Sanskrit und Deutsch herausgegeben von Dr. Adolph Friedrich Stenzler. Berlin und London 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, s. Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.
@@ -1032,6 +1034,8 @@ St. Petersburg, / Tübingen, den 1/13 Juli 1861.
 <sub>Quelle (Scan): [pwg3-0000--03.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref19.html)</sub>
 
 Erklärung der im dritten Theile neu hinzugekommenen Abkürzungen.
+
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, handschriftlich in der Pariser Bibliothek, nach Mittheilungen von A. Schiefner.
 
 DAŚABH. = DAÇABHŪMIÇVARA, handschriftlich in der Pariser Bibliothek, nach Mittheilungen von A. Schiefner.
 

--- a/prefaces/pwgpref_all.en.md
+++ b/prefaces/pwgpref_all.en.md
@@ -209,7 +209,7 @@ Many a deficiency of the dictionary may find its excuse in the fact that its two
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Ms.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, a scholiast of the Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Cited according to the 8 Pańḱikâ (an external division, into which the 40 Adhjâja formed on factual considerations are split) and the chapter numbers running continuously within the Pańḱikâ. Ms. Sâjana's Commentary thereto. Ms.
@@ -355,8 +355,10 @@ II
 
 <sub>Source (scan): [pwg1-0000--09.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref09.html)</sub>
 
-[Paris 1829.] (Continuation of the preceding entry)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = Jâǵńavalkja's law book. Sanskrit and German edited by Dr. Adolph Friedrich Stenzler. Berlin and London 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, see Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.
@@ -1032,6 +1034,8 @@ St. Petersburg, / Tübingen, 1/13 July 1861.
 <sub>Source (scan): [pwg3-0000--03.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref19.html)</sub>
 
 Explanation of the abbreviations newly added in the third Part.
+
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, in manuscript in the Paris Library, after communications from A. Schiefner.
 
 DAŚABH. = DAÇABHŪMIÇVARA, in manuscript in the Paris Library, after communications from A. Schiefner.
 

--- a/prefaces/pwgpref_all.ru.md
+++ b/prefaces/pwgpref_all.ru.md
@@ -205,7 +205,7 @@ Gṛhjasûtra Çâṅkhâjana начал использовать для наш�
 **Âśv. Gṛhy.** = Âçvalâjana's Gṛhjasûtrâni in 4 Adhjâja. Рук.
 **Adbh. Br.** = Adbhutabrâhmaṇa.
 **Adbhutas.** = Adbhutasâra.
-**A Dict. Beng. and S.** = A Dictionary Bengali and Sanskrit, explained in English.
+**A Dict. Beng. and S. (Haughton,)** = A Dictionary Bengali and Sanskrit, explained in English.
 **Agnisv.** = Agnisvâmin, схолиаст Lâṭjâjana.
 **Âhnikat.** = Âhnikatattva.
 **Ait. Br.** = Aitarejabrâhmaṇa. Цитируется по 8 Pańḱikâ (внешнему разделению, на которое разбиты 40 Adhjâja, образованных по содержательным соображениям) и по номерам глав, идущим сквозной нумерацией внутри Pańḱikâ. Рук. Комментарий Sâjana к нему. Рук.
@@ -351,8 +351,10 @@ II
 
 <sub>Источник (скан): [pwg1-0000--09.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref09.html)</sub>
 
-[Paris 1829.] (Продолжение предыдущей записи)
-**Yaj. V.** = Jaǵurveda.
+**Itih.** = Itihâsa.
+**Jâǵń.** = законодательный свод Jâǵńavalkja. Издано на санскрите и немецком д-ром Adolph Friedrich Stenzler. Берлин и Лондон, 1849.
+**Jaǵńad. (Lois.)** = Yadjnadattabadha, ou la mort de Yadjnadatta, épisode du Ramajana, publié u. s. w. par Auguste Loiseleur Deslongchamps. Paris 1829.
+**Jaǵ. V.** = Jaǵurveda.
 **Yavaneśv.** = Javaneçvara.
 **Jogat.** = Jogatattva, см. Ind. St. 2, 49.
 **Journ. as.** = Journal asiatique.
@@ -1020,6 +1022,8 @@ St. Petersburg
 <sub>Источник (скан): [pwg3-0000--03.png](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/pwgpref/pwgpref19.html)</sub>
 
 Объяснение сокращений, вновь добавленных в третьем томе.
+
+BUDDHOKT. = BUDDHOKTASAṂSĀRĀMAJA, в рукописи в Парижской библиотеке, по сообщениям А. Шифнера.
 
 DAŚABH. = DAÇABHŪMIÇVARA, в рукописи в Парижской библиотеке, по сообщениям А. Шифнера.
 


### PR DESCRIPTION
## Summary
- `pwgpref07.md` (+en/ru): restore missing `(Haughton,)` attribution on the `A Dict. Beng. and S.` key, verified against `scans/pwg1-0000--06.png`.
- `pwgpref09.md` (+en/ru): the opening line was a fabricated "Fortsetzung des vorhergehenden Eintrags" note papering over 3 real entries lost at a page-boundary OCR crop (`Itih.`, `Jâǵń.`, `Jaǵńad. (Lois.)`); replaced with the actual scan text, and re-verified the pre-existing `Jaǵ. V. = Jaǵurveda.` key/diacritics against `scans/pwg1-0000--09.png` (key is `Jaǵ.`, not `Yaj.`).
- `pwgpref19.md` (+en/ru): boundary-scanning pwgpref08/10/11/19 (per H1721 scope) found the same failure mode recurring — the first entry `Buddhokt. = Buddhoktasaṃsārāmaja...` was missing from the top of the page, verified against `scans/pwg3-0000--03.png`. pwgpref08/10/11 first+last entries checked clean against their scans.
- `pwgpref_all.de/en/ru.md` regenerated via `prefaces/build_combined.py`.

Companion PWK PR (H1721) fixes the `pwpref03.md` `Golâdhj.` omission.

Tracking: sanskrit-lexicon/PWG#210

## Test plan
- [x] Diffed each corrected entry against its scan PNG
- [x] Regenerated combined DE/EN/RU files and diffed output