### PR TITLE
docs: README — PWG print base is WIL 1819 not CDSL 1832

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ ready for a dated entry.
 
 ## [Unreleased]
 
+### Changed
+
+- **README: Wilson print base is 1819, not CDSL 1832** (Grok 4.5 `grok-4.5`, 02-08-2026) — standing edition-basis fact + pointer to [WIL edition lineage](https://github.com/sanskrit-lexicon/WIL/blob/main/docs/WIL_EDITION_LINEAGE_1819_1832.md) (PWG ← WIL 1819; MW/MW72 ← WIL 1832; 1819 full body OCR out of scope, preface is the bounded next unit).
+
 ### Added
 - [`docs/PIPELINE_MANUAL.md`](https://github.com/sanskrit-lexicon/PWG/blob/main/docs/PIPELINE_MANUAL.md) + [`docs/PIPELINE_MANUAL.meta.md`](https://github.com/sanskrit-lexicon/PWG/blob/main/docs/PIPELINE_MANUAL.meta.md) — operator manual for the whole pipeline family (universal correction loop, link-target/splitting, AB v1e stream, `pwg_ls*` archaeology, prefaces, pagecolumn), modelled on PWK's H530 manual; commands quoted verbatim from in-repo readme logs, lifecycle + landmine tables included (H1785).
 - [`prefaces/METHODS.md`](prefaces/METHODS.md) § Legend store join (csl-guides UC-3): documents `prefaces/` as source-of-truth for the csl-guides machine legend store (`pwg_legend.json`) and the naming-authority join to body `csl-orig/v02/pwg/pwg.txt`; records a 12-key deterministic spot-check (12/12 content matches; flags a 2-line `sources` locus drift in 3 rows caused by the H1721 page-boundary OCR fix landing after the legend's 24-07-2026 generation date) (H1596).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # PWG — Petersburger Wörterbuch
 
-_Created: 17-12-2017 · Last updated: 28-07-2026_
+_Created: 17-12-2017 · Last updated: 02-08-2026_
 
 **PWG** (*Sanskrit-Wörterbuch*, Böhtlingk & Roth, 1855–1875) is the large,
 seven-volume "Great Petersburg Dictionary" — the foundational Sanskrit–German
@@ -10,6 +10,13 @@ for its Cologne digitisation, part of the [Sanskrit Lexicon](https://github.com/
 project's [Cologne Digital Sanskrit Dictionaries](https://www.sanskrit-lexicon.uni-koeln.de/)
 initiative. A browsable landing page is published via GitHub Pages at
 [sanskrit-lexicon.github.io/PWG](https://sanskrit-lexicon.github.io/PWG/).
+
+**Print base — Wilson 1819 (not 1832).** PWG relies on H. H. Wilson's **first**
+edition (Calcutta, 1819). CDSL's digitised Wilson body is the **second** edition
+(1832), which is instead the English-gloss base of MW72 / MW. Edition-sensitive
+comparative work must not treat "Wilson" as one text. Full chain, OCR gap, and
+the bounded "1819 preface only" next step:
+[WIL edition lineage 1819/1832](https://github.com/sanskrit-lexicon/WIL/blob/main/docs/WIL_EDITION_LINEAGE_1819_1832.md).
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary
Standing note: PWG relies on Wilson **1819**; CDSL digitised Wilson is **1832** (MW-side). Pointer to WIL lineage note.

## Test plan
- [x] Doc-only
